### PR TITLE
chore(client): make chat button no longer hide with window state

### DIFF
--- a/client/ChatForm/ChatForm.UI.cs
+++ b/client/ChatForm/ChatForm.UI.cs
@@ -123,7 +123,7 @@ namespace RobloxChatLauncher
                 mainContainer.Visible = !isWindowHidden;
 
                 // Also hide the toggle button itself when the window is hidden
-                toggleBtn.Visible = !isWindowHidden;
+                // toggleBtn.Visible = !isWindowHidden;
 
                 // Update the visual state of the button
                 toggleBtn.IsActive = !isWindowHidden;


### PR DESCRIPTION
Commented out the line that controls the visibility of the toggle button when the window is hidden. This is in preparation for refactoring/migration to WPF, which will restore click functionality (no longer relying only on hotkeys) for the button.