### PR TITLE
fix(ci): update label for bump integrations submodule workflow

### DIFF
--- a/.github/workflows/bump-integrations-submodule.yml
+++ b/.github/workflows/bump-integrations-submodule.yml
@@ -45,7 +45,7 @@ jobs:
           body: |
             Bumps the integrations submodule reference from commit ${{ steps.check.outputs.old_sha }} to ${{ steps.check.outputs.new_sha }}. 
           labels: |
-            integrations 
+            area:integrations 
             github_actions
           branch: chore/bump-integrations-submodule
           delete-branch: true


### PR DESCRIPTION
Change label from 'integrations' to 'area:integrations' in workflow.